### PR TITLE
Feat: Add swagger documentation for email reg

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,7 @@ ADMIN_SECRET_KEY=praivet key admin
 ADMIN_AUTH_KEY=password
 TESTNET_FUTURENET_RPC_URL='https://rpc-futurenet.stellar.org'
 BASE_FEE=100000
+
+# EmailConfig
+MAILER_SERVICE_USER=address@gmail.com
+MAC_MAILER_SERVICE_PASS=xxxxxxxxxxxxxxxx

--- a/src/routes/subscribe/add.ts
+++ b/src/routes/subscribe/add.ts
@@ -31,7 +31,7 @@ const addSubscriber: RequestHandler = async (req, res) => {
     // Check if email is already registered
     const existingSubscriber = await Subscriber.findOne({ email: eAddress });
     if (existingSubscriber) {
-      return res.status(400).j({
+      return res.status(409).j({
         status: 'error',
         message: 'Email already joined',
         result: {},

--- a/src/routes/subscribe/index.ts
+++ b/src/routes/subscribe/index.ts
@@ -2,10 +2,11 @@ import express from 'express';
 
 import addSubscriber from './add';
 import getSubscribers from './get';
+import authAdmin from '../../middleware/authAdmin';
 
 const router = express.Router();
 
 router.post('/', addSubscriber);
-router.get('/', getSubscribers);
+router.get('/', authAdmin, getSubscribers);
 
 export default router;

--- a/src/routes/swagger/configSwagger.ts
+++ b/src/routes/swagger/configSwagger.ts
@@ -17,7 +17,7 @@ const configSwagger = () => {
         },
       ],
     },
-    apis: ['./src/swagger/token/*.ts'],
+    apis: ['./src/swagger/**/*.ts'],
   };
   return options;
 };

--- a/src/swagger/subscribe/add.ts
+++ b/src/swagger/subscribe/add.ts
@@ -1,10 +1,37 @@
 /**
  * @swagger
- * /subscribers:
+ * components:
+ *   schemas:
+ *     Subscriber:
+ *       type: object
+ *       required:
+ *         - email
+ *       properties:
+ *         email:
+ *           type: string
+ *           format: email
+ *           description: Email address of the subscriber.
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           description: The date when the subscriber was created.
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *           description: The date when the subscriber was last updated.
+ *       example:
+ *         email: example@example.com
+ *         createdAt: '2021-01-01T00:00:00Z'
+ *         updatedAt: '2021-01-01T00:00:00Z'
+ */
+
+/**
+ * @swagger
+ * /subscribe:
  *   post:
  *     tags:
- *       - Subscribers
- *     summary: Add a new subscriber
+ *       - Subscribe
+ *     summary: Adds a new subscriber
  *     description: Endpoint to add a new subscriber to the mailing list.
  *     requestBody:
  *       required: true

--- a/src/swagger/subscribe/add.ts
+++ b/src/swagger/subscribe/add.ts
@@ -1,0 +1,88 @@
+/**
+ * @swagger
+ * /subscribers:
+ *   post:
+ *     tags:
+ *       - Subscribers
+ *     summary: Add a new subscriber
+ *     description: Endpoint to add a new subscriber to the mailing list.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 description: The subscriber's email address.
+ *             required:
+ *               - email
+ *             example:
+ *               email: user@example.com
+ *     responses:
+ *       201:
+ *         description: Subscriber added successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: Subscriber saved successfully
+ *                 result:
+ *                   $ref: '#/components/schemas/Subscriber'
+ *       400:
+ *         description: Bad request when input validation fails.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: error
+ *                 message:
+ *                   type: string
+ *                   example: Invalid email format
+ *                 result:
+ *                   type: object
+ *                   example: {}
+ *       409:
+ *         description: Conflict when email is already registered.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: error
+ *                 message:
+ *                   type: string
+ *                   example: Email already joined
+ *                 result:
+ *                   type: object
+ *                   example: {}
+ *       500:
+ *         description: Internal server error when operation cannot be completed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: error
+ *                 message:
+ *                   type: string
+ *                   example: An error occurred while processing your request
+ *                 result:
+ *                   type: object
+ *                   example: {}
+ */

--- a/src/swagger/subscribe/get.ts
+++ b/src/swagger/subscribe/get.ts
@@ -1,9 +1,36 @@
 /**
  * @swagger
- * /subscribers:
+ * components:
+ *   schemas:
+ *     Subscriber:
+ *       type: object
+ *       required:
+ *         - email
+ *       properties:
+ *         email:
+ *           type: string
+ *           format: email
+ *           description: Email address of the subscriber.
+ *         createdAt:
+ *           type: string
+ *           format: date-time
+ *           description: The date when the subscriber was created.
+ *         updatedAt:
+ *           type: string
+ *           format: date-time
+ *           description: The date when the subscriber was last updated.
+ *       example:
+ *         email: example@example.com
+ *         createdAt: '2021-01-01T00:00:00Z'
+ *         updatedAt: '2021-01-01T00:00:00Z'
+ */
+
+/**
+ * @swagger
+ * /subscribe:
  *   get:
  *     tags:
- *       - Subscribers
+ *       - Subscribe
  *     summary: Retrieves a list of all subscribers.
  *     description: This endpoint retrieves all the subscribers from the database.
  *     responses:
@@ -21,9 +48,7 @@
  *                   type: string
  *                   example: Subscribers found successfully
  *                 result:
- *                   type: array
- *                   items:
- *                     $ref: '#/components/schemas/Subscriber'
+ *                   $ref: '#/components/schemas/Subscriber'
  *       500:
  *         description: Internal server error when the operation fails.
  *         content:

--- a/src/swagger/subscribe/get.ts
+++ b/src/swagger/subscribe/get.ts
@@ -1,0 +1,42 @@
+/**
+ * @swagger
+ * /subscribers:
+ *   get:
+ *     tags:
+ *       - Subscribers
+ *     summary: Retrieves a list of all subscribers.
+ *     description: This endpoint retrieves all the subscribers from the database.
+ *     responses:
+ *       200:
+ *         description: A list of subscribers.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: success
+ *                 message:
+ *                   type: string
+ *                   example: Subscribers found successfully
+ *                 result:
+ *                   type: array
+ *                   items:
+ *                     $ref: '#/components/schemas/Subscriber'
+ *       500:
+ *         description: Internal server error when the operation fails.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: string
+ *                   example: error
+ *                 message:
+ *                   type: string
+ *                   example: An error occurred while processing your request.
+ *                 result:
+ *                   type: object
+ */

--- a/src/swagger/subscribe/get.ts
+++ b/src/swagger/subscribe/get.ts
@@ -1,6 +1,11 @@
 /**
  * @swagger
  * components:
+ *   securitySchemes:
+ *     Authorization:
+ *       type: apiKey
+ *       in: header
+ *       name: authorization
  *   schemas:
  *     Subscriber:
  *       type: object
@@ -33,6 +38,8 @@
  *       - Subscribe
  *     summary: Retrieves a list of all subscribers.
  *     description: This endpoint retrieves all the subscribers from the database.
+ *     security:
+ *       - Authorization: [] 
  *     responses:
  *       200:
  *         description: A list of subscribers.


### PR DESCRIPTION
Pull Request Summary

This pull request adds swagger documentation to user email registration functionality.

Changes:

- The response code for "email already exists" changed to 409.
- Swagger documentation for adding and getting subscribers has been done.
- nodemailer configs were added to the .env.example file for better reference.